### PR TITLE
Specifying Scipy version

### DIFF
--- a/src/marian_cpu_preset.sh
+++ b/src/marian_cpu_preset.sh
@@ -1,0 +1,13 @@
+yes | sudo apt update
+yes | sudo apt install python3
+yes | sudo apt upgrade python3
+sudo apt update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
+yes | sudo apt install python3-pip
+yes | sudo apt-get install cmake git build-essential doxygen libgoogle-perftools-dev google-perftools libz-dev libboost-all-dev zlib1g-dev libprotobuf10 protobuf-compiler libprotobuf-dev openssl libssl-dev ant zip unzip
+wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
+sudo apt-get update
+yes | sudo apt-get install intel-mkl-64bit-2019.4-070
+git clone https://github.com/RikVN/Neural_DRS.git
+chmod +x ./Neural_DRS/src/setup.sh

--- a/src/setup.sh
+++ b/src/setup.sh
@@ -15,7 +15,7 @@ git clone https://github.com/RikVN/DRS_parsing
 cd DRS_parsing
 git checkout v.2.2.0
 pip install -r requirements.txt
-pip install scipy
+pip install scipy==1.3.1
 
 # The files in the DRS_parsing repo only have gold and silver separately
 # Combine them to files with gold + silver to reproduce experiments


### PR DESCRIPTION
The setup script first installs numpy==1.15.4 from requirements.txt. While installing scipy, since the version is not mentioned, it takes the recent scipy version (1.4.1) which has dependency of numpy==1.18.1. This creates 2 different site-packages for numpy in the environment.
While running the  unit_tests.sh, it throws error for having two numpy versions in the same environment.
The existing version of scipy when setup.sh file was committed was scipy==1.3.1.

This commit will prevent the script from breaking.